### PR TITLE
Notebook error resolution

### DIFF
--- a/whatsapp_wrapped/analytics.py
+++ b/whatsapp_wrapped/analytics.py
@@ -42,6 +42,7 @@ class ChatAnalytics:
     total_messages: int
     total_members: int
     total_words: int
+    total_days: int
     messages_per_day: float
     most_active_day: str
     most_active_hour: int
@@ -671,6 +672,7 @@ def analyze_chat(df: pl.DataFrame) -> ChatAnalytics:
         total_messages=total_messages,
         total_members=total_members,
         total_words=total_words,
+        total_days=num_days,
         messages_per_day=messages_per_day,
         most_active_day=most_active_day,
         most_active_hour=most_active_hour,


### PR DESCRIPTION
Add `total_days` attribute to `ChatAnalytics` to resolve an `AttributeError` when accessing it in the notebook.

The notebook was attempting to access `analytics.total_days`, but this attribute was missing from the `ChatAnalytics` dataclass, leading to an `AttributeError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a984cad-892c-4a9a-be62-be1e2efa6ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a984cad-892c-4a9a-be62-be1e2efa6ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

