### PR TITLE
Add date format for german export format.

### DIFF
--- a/whatsapp_wrapped/parser.py
+++ b/whatsapp_wrapped/parser.py
@@ -43,6 +43,7 @@ DATE_FORMATS = [
     "%Y-%m-%d, %H:%M:%S",  # ISO-ish format
     "%d.%m.%y, %H:%M:%S",  # German format with dots
     "%d.%m.%Y, %H:%M:%S",
+    "%d.%m.%Y, %H:%M",  # DD.MM.YYYY, HH:MM (German format with dots, 4-digit year, no seconds)
     # 12-hour AM/PM formats
     "%m/%d/%y, %I:%M:%S %p",  # US 12-hour with seconds: 12/25/23, 3:45:30 PM
     "%m/%d/%y, %I:%M %p",  # US 12-hour: 12/25/23, 3:45 PM


### PR DESCRIPTION
Hello!
First of all, thank you for this cool tool! I tested it with an export from the German Whatsapp App (Android 16), which resulted in an error:
```
[!] Error: Could not parse any messages from the chat. The format may not be supported.
```
After quick investigations, I found out that the time format of a German chat export is not supported. The chat export file looks like:
```
03.08.21, 12:30 - message 1
03.08.21, 12:30 - message 2
...
```
This PR adds the date format to the parser which enables generating reports with German chat exports.